### PR TITLE
Removed auto-git status & conflict from clink.   

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -296,9 +296,9 @@ local function git_prompt_filter()
         local color
         if branch then
             -- Has branch => therefore it is a git folder, now figure out status
-            local gitStatus = get_git_status()
-            local gitConflict = get_git_conflict()
-
+            --local gitStatus = get_git_status()
+            --local gitConflict = get_git_conflict()
+-- REMOVED gitStatus to check if hangs stop inside EPICS dir
             color = colors.dirty
             if gitStatus then
                 color = colors.clean


### PR DESCRIPTION
Due to the large number of modules in top level projects git repositories, the auto-status is exceptionally annoying. I've removed it to make navigating the file structures bearable for these projects. The clink git colour no longer works as a side effect.